### PR TITLE
vsnprintf needs stdio

### DIFF
--- a/src/strlib.cpp
+++ b/src/strlib.cpp
@@ -12,6 +12,7 @@
 
 
 #include <cstdarg>
+#include <cstdio>
 
 #include "strlib.h"
 


### PR DESCRIPTION
Addressing error during make:

```
strlib.cpp: In function ‘std::string str::printf(const char*, ...)’:
strlib.cpp:145:58: error: ‘vsnprintf’ was not declared in this scope
make[2]: *** [strlib.o] Error 1
```
