### PR TITLE
Adding lua version max so that later versions of lua will build

### DIFF
--- a/README
+++ b/README
@@ -13,7 +13,7 @@ repository data.
 
 This README file contains brief configuration, installation and usage
 instructions. Additional documentation is available at the project
-homepage at <http://scm-pepper.sourceforge.net>.
+homepage at <https://jgehring.github.io/pepper/>.
 
 
 Requirements

--- a/configure.ac
+++ b/configure.ac
@@ -97,7 +97,7 @@ for with_lua_suffix in $LUA_SUFFIXES; do
 	if test "x$LUA" = "x"; then
 		continue
 	fi
-	AX_LUA_VERSION([501])
+	AX_LUA_VERSION([501],[503])
 	AX_LUA_HEADERS()
 	AX_LUA_HEADERS_VERSION([501])
 	if test "x$LUA_HEADERS_IN_RANGE" != "xyes"; then


### PR DESCRIPTION
I noticed that I was unable to configure pepper on my system despite having lua 5.3 installed. When I dug into it, I found out that the AX_LUA_VERSION macro supports two parameters, a minimum version as well as a maximum version. If no maximum version is supplied, it defaults to adding 1 to the minimum version. Since I have been able to build and roughly test pepper with lua 5.3 I have added a maximum version parameter to the script to prevent others from struggling with this.
